### PR TITLE
Provide a routes.remove function

### DIFF
--- a/route-builder.js
+++ b/route-builder.js
@@ -41,6 +41,20 @@ RouteBuilder.prototype.add = function(name, path, meta) {
   return this;
 };
 
+/**
+ * @param {String|Array} name name(s) of route(s) to remove
+ */
+RouteBuilder.prototype.remove = function (name) {
+  if (typeof name === 'string') {
+    name = [name];
+  } else if (!Array.isArray(name)) {
+    throw new Error('"name" must be specified');
+  }
+
+  this._routes = this._routes.filter(function (route) {
+    return name.indexOf(route.name) === -1;
+  });
+}
 
 /**
  * @param {String} path

--- a/test/route-builder-test.js
+++ b/test/route-builder-test.js
@@ -33,6 +33,30 @@ describe('route-builder', function() {
     });
   });
 
+  describe('#remove', function () {
+    it('should remove a route by name', function () {
+      var router = new RouteBuilder(TestRoutes);
+      router.remove(TestRoutes[1][0]);
+      assert.equal(Object.keys(router._routes).length, TestRoutes.length - 1);
+    });
+    it('should remove multiple routes when passed an array of names', function () {
+      var router = new RouteBuilder(TestRoutes);
+      var removeRoutes = [TestRoutes[1][0], TestRoutes[3][0]];
+      router.remove(removeRoutes);
+      assert.equal(Object.keys(router._routes).length, TestRoutes.length - removeRoutes.length);
+    });
+    it('should not remove a route when passed a non-existant name', function () {
+      var router = new RouteBuilder(TestRoutes);
+      router.remove('NonExistantName');
+      assert.equal(Object.keys(router._routes).length, TestRoutes.length);
+    });
+    it('should remove only items in the names array if they exist', function () {
+      var router = new RouteBuilder(TestRoutes);
+      router.remove([TestRoutes[1][0], 'NonExistantName']);
+      assert.equal(Object.keys(router._routes).length, TestRoutes.length - 1);
+    })
+  });
+
   describe('#hasMatch', function() {
     it('should match an existing route', function() {
       var router = new RouteBuilder(TestRoutes);


### PR DESCRIPTION
route-builder provides a nice base router. To be able to use it for
dynamic routing, for example in a CMS where pages get added or removed at
runtime, a route should be removable.

This commit provides the function with test coverage.
